### PR TITLE
Add resource to soft delete monitored resource, fix aggregations

### DIFF
--- a/app/airview_api/models/models.py
+++ b/app/airview_api/models/models.py
@@ -28,6 +28,8 @@ class MonitoredResourceState(Enum):
     SUPPRESSED = 2
     FIXED_AUTO = 3
     FIXED_OTHER = 4
+    MONITORING = 5
+    CANCELLED = 6
 
     def __str__(self):
         return self.name

--- a/app/airview_api/services/aggregation_service.py
+++ b/app/airview_api/services/aggregation_service.py
@@ -66,6 +66,7 @@ from
     on s.id = tc.system_id
 where
   tc.quality_model = :quality_model
+  and mr.monitoring_state != 'CANCELLED'
 group by
   tc.id,
   tc.name,
@@ -126,6 +127,7 @@ where
         .join(Application)
         .join(Environment, isouter=True)
         .filter(MonitoredResource.id.in_(ids))
+        .filter(MonitoredResource.monitoring_state != MonitoredResourceState.CANCELLED)
     )
     print(data)
     d = data.all()

--- a/app/tests/api_tests/test_aggregations.py
+++ b/app/tests/api_tests/test_aggregations.py
@@ -123,6 +123,15 @@ def _prepare_aggregation_mock_data():
         last_seen=datetime(6, 1, 1, tzinfo=timezone.utc),
         last_modified=datetime(6, 1, 1, tzinfo=timezone.utc),
     )
+    # Cancelled Resource -  should be ignored
+    MonitoredResourceFactory(
+        id=110,
+        application_technical_control_id=33,
+        reference="res-55",
+        monitoring_state=MonitoredResourceState.CANCELLED,
+        last_seen=datetime(4, 1, 1, tzinfo=timezone.utc),
+        last_modified=datetime(4, 1, 1, tzinfo=timezone.utc),
+    )
     # Items not created until something is invoked, probably because of underlying raw query
     Application.query.all()
 


### PR DESCRIPTION
Relates to AirWalk-Digital/airview-issues#141 

Adds functionality to support soft deletes via existing PUT of monitored resources.