### PR TITLE
Test using Postgresql as a backend

### DIFF
--- a/app/airview_api/services/application_service.py
+++ b/app/airview_api/services/application_service.py
@@ -1,5 +1,5 @@
 from sqlalchemy import func
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, DataError
 from sqlalchemy.log import Identified
 from airview_api.services import AirViewValidationException, AirViewNotFoundException
 from airview_api.models import (
@@ -87,7 +87,9 @@ def create(data: dict):
 
         db.session.add(app)
         db.session.commit()
-    except IntegrityError:
+    except (IntegrityError, DataError) as e:
+        print(e)
+
         db.session.rollback()
         raise AirViewValidationException("Integrity Error, check reference fields")
     return app
@@ -103,6 +105,6 @@ def update(data: dict):
     app.environment_id = data.get("environment_id")
     try:
         db.session.commit()
-    except IntegrityError:
+    except (IntegrityError, DataError):
         db.session.rollback()
         raise AirViewValidationException("Integrity Error, check reference fields")

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -12,3 +12,4 @@ factory-boy==3.2.0
 responses==0.13.2
 requests-mock==1.9.3
 requests-flask-adapter==0.1.0
+testing.postgresql==1.3.0

--- a/app/tests/api_tests/test_aggregations.py
+++ b/app/tests/api_tests/test_aggregations.py
@@ -13,6 +13,7 @@ from airview_api.models import (
     TechnicalControlType,
     SystemStage,
 )
+import unittest
 
 
 def setup():
@@ -680,4 +681,5 @@ def test_get_quality_models_for_app(client):
             "name": "COST_OPTIMISATION",
         },
     ]
-    assert expected == data
+    case = unittest.TestCase()
+    case.assertCountEqual(expected, data)

--- a/app/tests/api_tests/test_aggregations.py
+++ b/app/tests/api_tests/test_aggregations.py
@@ -77,8 +77,8 @@ def _prepare_aggregation_mock_data():
         application_technical_control_id=33,
         reference="res-1",
         monitoring_state=MonitoredResourceState.SUPPRESSED,
-        last_seen=datetime(2, 1, 1, tzinfo=timezone.utc),
-        last_modified=datetime(2, 1, 1, tzinfo=timezone.utc),
+        last_seen=datetime(2002, 1, 1, tzinfo=timezone.utc),
+        last_modified=datetime(2002, 1, 1, tzinfo=timezone.utc),
     )
     # ctl 1 -Second resource
     MonitoredResourceFactory(
@@ -86,8 +86,8 @@ def _prepare_aggregation_mock_data():
         application_technical_control_id=33,
         reference="res-2",
         monitoring_state=MonitoredResourceState.FLAGGED,
-        last_seen=datetime(3, 1, 1, tzinfo=timezone.utc),
-        last_modified=datetime(3, 1, 1, tzinfo=timezone.utc),
+        last_seen=datetime(2003, 1, 1, tzinfo=timezone.utc),
+        last_modified=datetime(2003, 1, 1, tzinfo=timezone.utc),
     )
     # ctl2 - Different control
     MonitoredResourceFactory(
@@ -95,8 +95,8 @@ def _prepare_aggregation_mock_data():
         application_technical_control_id=34,
         reference="res-3",
         monitoring_state=MonitoredResourceState.FLAGGED,
-        last_seen=datetime(4, 1, 1, tzinfo=timezone.utc),
-        last_modified=datetime(4, 1, 1, tzinfo=timezone.utc),
+        last_seen=datetime(2004, 1, 1, tzinfo=timezone.utc),
+        last_modified=datetime(2004, 1, 1, tzinfo=timezone.utc),
     )
     # Ctl1 via different app
     MonitoredResourceFactory(
@@ -104,8 +104,8 @@ def _prepare_aggregation_mock_data():
         application_technical_control_id=35,
         reference="res-4",
         monitoring_state=MonitoredResourceState.FLAGGED,
-        last_seen=datetime(5, 1, 1, tzinfo=timezone.utc),
-        last_modified=datetime(5, 1, 1, tzinfo=timezone.utc),
+        last_seen=datetime(2005, 1, 1, tzinfo=timezone.utc),
+        last_modified=datetime(2005, 1, 1, tzinfo=timezone.utc),
     )
     # Unrelated data
     MonitoredResourceFactory(
@@ -113,16 +113,16 @@ def _prepare_aggregation_mock_data():
         application_technical_control_id=36,
         reference="res-1-x",
         monitoring_state=MonitoredResourceState.FLAGGED,
-        last_seen=datetime(6, 1, 1, tzinfo=timezone.utc),
-        last_modified=datetime(6, 1, 1, tzinfo=timezone.utc),
+        last_seen=datetime(2006, 1, 1, tzinfo=timezone.utc),
+        last_modified=datetime(2006, 1, 1, tzinfo=timezone.utc),
     )
     MonitoredResourceFactory(
         id=107,
         application_technical_control_id=37,
         reference="res-1-x",
         monitoring_state=MonitoredResourceState.FLAGGED,
-        last_seen=datetime(6, 1, 1, tzinfo=timezone.utc),
-        last_modified=datetime(6, 1, 1, tzinfo=timezone.utc),
+        last_seen=datetime(2006, 1, 1, tzinfo=timezone.utc),
+        last_modified=datetime(2006, 1, 1, tzinfo=timezone.utc),
     )
     # Cancelled Resource -  should be ignored
     MonitoredResourceFactory(
@@ -130,8 +130,8 @@ def _prepare_aggregation_mock_data():
         application_technical_control_id=33,
         reference="res-55",
         monitoring_state=MonitoredResourceState.CANCELLED,
-        last_seen=datetime(4, 1, 1, tzinfo=timezone.utc),
-        last_modified=datetime(4, 1, 1, tzinfo=timezone.utc),
+        last_seen=datetime(2004, 1, 1, tzinfo=timezone.utc),
+        last_modified=datetime(2004, 1, 1, tzinfo=timezone.utc),
     )
     # Items not created until something is invoked, probably because of underlying raw query
     Application.query.all()
@@ -143,8 +143,8 @@ def _prepare_additional_data():  # Add additional exemptions
         application_technical_control_id=37,
         reference="res-1-other-2",
         monitoring_state=MonitoredResourceState.SUPPRESSED,
-        last_modified=datetime(6, 1, 1, tzinfo=timezone.utc),
-        last_seen=datetime(6, 1, 1, tzinfo=timezone.utc),
+        last_modified=datetime(2006, 1, 1, tzinfo=timezone.utc),
+        last_seen=datetime(2006, 1, 1, tzinfo=timezone.utc),
     )
 
     MonitoredResourceFactory(
@@ -152,8 +152,8 @@ def _prepare_additional_data():  # Add additional exemptions
         application_technical_control_id=37,
         reference="res-1-other-3",
         monitoring_state=MonitoredResourceState.SUPPRESSED,
-        last_modified=datetime(6, 1, 1, tzinfo=timezone.utc),
-        last_seen=datetime(6, 1, 1, tzinfo=timezone.utc),
+        last_modified=datetime(2006, 1, 1, tzinfo=timezone.utc),
+        last_seen=datetime(2006, 1, 1, tzinfo=timezone.utc),
     )
     ExclusionFactory(
         id=44,
@@ -163,7 +163,7 @@ def _prepare_additional_data():  # Add additional exemptions
         impact=3,
         probability=4,
         is_limited_exclusion=True,
-        end_date=datetime(1, 1, 1, tzinfo=timezone.utc),
+        end_date=datetime(2001, 1, 1, tzinfo=timezone.utc),
         notes="nnn",
     )
     mr = MonitoredResource.query.get(103)
@@ -197,7 +197,7 @@ def test_get_control_status_aggregation(client):
             "environment": "PRD",
             "application": "svc 12",
             "resources": [{"id": 103, "name": "res-2", "state": "NONE"}],
-            "raisedDateTime": "0003-01-01T00:00:00",
+            "raisedDateTime": "2003-01-01T00:00:00+00:00",
             "tickets": [],
         },
         {
@@ -210,7 +210,7 @@ def test_get_control_status_aggregation(client):
             "environment": "DEV",
             "application": "svc 13",
             "resources": [{"id": 105, "name": "res-4", "state": "NONE"}],
-            "raisedDateTime": "0005-01-01T00:00:00",
+            "raisedDateTime": "2005-01-01T00:00:00+00:00",
             "tickets": [],
         },
         {
@@ -223,11 +223,12 @@ def test_get_control_status_aggregation(client):
             "environment": "PRD",
             "application": "svc 12",
             "resources": [{"id": 104, "name": "res-3", "state": "NONE"}],
-            "raisedDateTime": "0004-01-01T00:00:00",
+            "raisedDateTime": "2004-01-01T00:00:00+00:00",
             "tickets": [],
         },
     ]
-    assert data == expected
+    case = unittest.TestCase()
+    case.assertCountEqual(expected, data)
 
 
 def test_get_control_status_aggregation_removes_active_exclusions(client):
@@ -246,7 +247,7 @@ def test_get_control_status_aggregation_removes_active_exclusions(client):
         impact=3,
         probability=4,
         is_limited_exclusion=True,
-        end_date=datetime(1, 1, 1, tzinfo=timezone.utc),
+        end_date=datetime(2001, 1, 1, tzinfo=timezone.utc),
         notes="nnn",
     )
 
@@ -272,7 +273,7 @@ def test_get_control_status_aggregation_removes_active_exclusions(client):
             "environment": "DEV",
             "application": "svc 13",
             "resources": [{"id": 105, "name": "res-4", "state": "NONE"}],
-            "raisedDateTime": "0005-01-01T00:00:00",
+            "raisedDateTime": "2005-01-01T00:00:00+00:00",
             "tickets": [],
         },
         {
@@ -285,11 +286,12 @@ def test_get_control_status_aggregation_removes_active_exclusions(client):
             "environment": "PRD",
             "application": "svc 12",
             "resources": [{"id": 104, "name": "res-3", "state": "NONE"}],
-            "raisedDateTime": "0004-01-01T00:00:00",
+            "raisedDateTime": "2004-01-01T00:00:00+00:00",
             "tickets": [],
         },
     ]
-    assert data == expected
+    case = unittest.TestCase()
+    case.assertCountEqual(expected, data)
 
 
 def test_get_control_status_aggregation_empty_result_for_unfound_app(client):
@@ -334,7 +336,7 @@ def test_get_control_status_aggregation_handles_no_children(client):
             "environment": "PRD",
             "application": "svc 12",
             "resources": [{"id": 103, "name": "res-2", "state": "NONE"}],
-            "raisedDateTime": "0003-01-01T00:00:00",
+            "raisedDateTime": "2003-01-01T00:00:00+00:00",
             "tickets": [],
         },
         {
@@ -347,12 +349,13 @@ def test_get_control_status_aggregation_handles_no_children(client):
             "environment": "PRD",
             "application": "svc 12",
             "resources": [{"id": 104, "name": "res-3", "state": "NONE"}],
-            "raisedDateTime": "0004-01-01T00:00:00",
+            "raisedDateTime": "2004-01-01T00:00:00+00:00",
             "tickets": [],
         },
     ]
     assert resp.status_code == 200
-    assert data == expected
+    case = unittest.TestCase()
+    case.assertCountEqual(expected, data)
 
 
 def test_get_application_compliance_overview(client):
@@ -415,7 +418,8 @@ def test_get_application_compliance_overview(client):
         },
     ]
 
-    assert expected == data
+    case = unittest.TestCase()
+    case.assertCountEqual(expected, data)
 
 
 def test_get_application_control_overview(client):
@@ -478,7 +482,8 @@ def test_get_application_control_overview_hides_parents(client):
             "systemStage": "BUILD",
         }
     ]
-    assert expected == data
+    case = unittest.TestCase()
+    case.assertCountEqual(expected, data)
 
 
 def test_get_control_overview_resources_with_children(client):
@@ -502,7 +507,7 @@ def test_get_control_overview_resources_with_children(client):
         {
             "environment": "bbb",
             "id": 102,
-            "lastSeen": "0002-01-01T00:00:00",
+            "lastSeen": "2002-01-01T00:00:00+00:00",
             "pending": False,
             "reference": "res-1",
             "state": "SUPPRESSED",
@@ -510,7 +515,7 @@ def test_get_control_overview_resources_with_children(client):
         {
             "environment": "bbb",
             "id": 103,
-            "lastSeen": "0003-01-01T00:00:00",
+            "lastSeen": "2003-01-01T00:00:00+00:00",
             "pending": False,
             "reference": "res-2",
             "state": "SUPPRESSED",  # Suppressed via exclusion
@@ -518,14 +523,15 @@ def test_get_control_overview_resources_with_children(client):
         {
             "environment": "aaa",
             "id": 105,
-            "lastSeen": "0005-01-01T00:00:00",
+            "lastSeen": "2005-01-01T00:00:00+00:00",
             "pending": False,
             "reference": "res-4",
             "state": "FLAGGED",
         },
     ]
 
-    assert expected == data
+    case = unittest.TestCase()
+    case.assertCountEqual(expected, data)
 
 
 def test_get_control_overview_resources_no_children(client):
@@ -548,13 +554,14 @@ def test_get_control_overview_resources_no_children(client):
         {
             "environment": "aaa",
             "id": 105,
-            "lastSeen": "0005-01-01T00:00:00",
+            "lastSeen": "2005-01-01T00:00:00+00:00",
             "pending": False,
             "reference": "res-4",
             "state": "FLAGGED",
         }
     ]
-    assert expected == data
+    case = unittest.TestCase()
+    case.assertCountEqual(expected, data)
 
 
 def test_get_control_overview_resources_pending(client):
@@ -581,7 +588,7 @@ def test_get_control_overview_resources_pending(client):
         {
             "environment": "bbb",
             "id": 102,
-            "lastSeen": "0002-01-01T00:00:00",
+            "lastSeen": "2002-01-01T00:00:00+00:00",
             "pending": False,
             "reference": "res-1",
             "state": "SUPPRESSED",
@@ -589,7 +596,7 @@ def test_get_control_overview_resources_pending(client):
         {
             "environment": "bbb",
             "id": 103,
-            "lastSeen": "0003-01-01T00:00:00",
+            "lastSeen": "2003-01-01T00:00:00+00:00",
             "pending": False,
             "reference": "res-2",
             "state": "SUPPRESSED",  # Suppressed via exclusion
@@ -597,14 +604,15 @@ def test_get_control_overview_resources_pending(client):
         {
             "environment": "aaa",
             "id": 105,
-            "lastSeen": "0005-01-01T00:00:00",
+            "lastSeen": "2005-01-01T00:00:00+00:00",
             "pending": True,
             "reference": "res-4",
             "state": "FLAGGED",
         },
     ]
 
-    assert expected == data
+    case = unittest.TestCase()
+    case.assertCountEqual(expected, data)
 
 
 def test_get_control_overview_resources_null_environment(client):
@@ -630,7 +638,7 @@ def test_get_control_overview_resources_null_environment(client):
         {
             "id": 102,
             "environment": None,
-            "lastSeen": "0002-01-01T00:00:00",
+            "lastSeen": "2002-01-01T00:00:00+00:00",
             "pending": False,
             "reference": "res-1",
             "state": "SUPPRESSED",
@@ -638,7 +646,7 @@ def test_get_control_overview_resources_null_environment(client):
         {
             "id": 103,
             "environment": None,
-            "lastSeen": "0003-01-01T00:00:00",
+            "lastSeen": "2003-01-01T00:00:00+00:00",
             "pending": False,
             "reference": "res-2",
             "state": "SUPPRESSED",  # Suppressed via exclusion
@@ -646,14 +654,15 @@ def test_get_control_overview_resources_null_environment(client):
         {
             "environment": "aaa",
             "id": 105,
-            "lastSeen": "0005-01-01T00:00:00",
+            "lastSeen": "2005-01-01T00:00:00+00:00",
             "pending": False,
             "reference": "res-4",
             "state": "FLAGGED",
         },
     ]
 
-    assert expected == data
+    case = unittest.TestCase()
+    case.assertCountEqual(expected, data)
 
 
 def test_get_quality_models_for_app(client):

--- a/app/tests/api_tests/test_monitored_resource_status.py
+++ b/app/tests/api_tests/test_monitored_resource_status.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from pprint import pprint
 from tests.factories import *
 from tests.common import client
@@ -96,13 +96,13 @@ def test_create_updates_when_existing_different_state(client):
     ApplicationTechnicalControlFactory(
         id=201, application_id=1, technical_control_id=101
     )
-    MonitoredResourceFactory(
+    item = MonitoredResourceFactory(
         id=301,
         reference="ref-1",
         monitoring_state=MonitoredResourceState.FLAGGED,
         application_technical_control_id=201,
-        last_modified=datetime(1, 1, 1),
-        last_seen=datetime(2, 1, 1),
+        last_modified=datetime(2001, 1, 1, tzinfo=timezone.utc),
+        last_seen=datetime(2002, 1, 1, tzinfo=timezone.utc),
     )
 
     input_data = {"monitoringState": "SUPPRESSED"}
@@ -121,8 +121,8 @@ def test_create_updates_when_existing_different_state(client):
     assert persisted.application_technical_control_id == 201
     assert persisted.reference == "ref-1"
     assert persisted.state == MonitoredResourceState.SUPPRESSED
-    assert persisted.last_modified > datetime(1, 1, 1)
-    assert persisted.last_seen > datetime(2, 1, 1)
+    assert persisted.last_modified > datetime(2001, 1, 1, tzinfo=timezone.utc)
+    assert persisted.last_seen > datetime(2002, 1, 1, tzinfo=timezone.utc)
 
 
 def test_create_updates_when_existing_same_state(client):
@@ -150,8 +150,8 @@ def test_create_updates_when_existing_same_state(client):
         reference="ref-1",
         monitoring_state=MonitoredResourceState.FLAGGED,
         application_technical_control_id=201,
-        last_modified=datetime(1, 1, 1),
-        last_seen=datetime(2, 1, 1),
+        last_modified=datetime(2001, 1, 1, tzinfo=timezone.utc),
+        last_seen=datetime(2002, 1, 1, tzinfo=timezone.utc),
     )
 
     input_data = {"monitoringState": "FLAGGED"}
@@ -170,5 +170,5 @@ def test_create_updates_when_existing_same_state(client):
     assert persisted.application_technical_control_id == 201
     assert persisted.reference == "ref-1"
     assert persisted.state == MonitoredResourceState.FLAGGED
-    assert persisted.last_modified == datetime(1, 1, 1)
-    assert persisted.last_seen > datetime(2, 1, 1)
+    assert persisted.last_modified == datetime(2001, 1, 1, tzinfo=timezone.utc)
+    assert persisted.last_seen > datetime(2002, 1, 1, tzinfo=timezone.utc)

--- a/app/tests/common.py
+++ b/app/tests/common.py
@@ -5,6 +5,7 @@ from sqlalchemy import event
 from sqlalchemy.engine import Engine
 from sqlite3 import Connection as SQLite3Connection
 import testing.postgresql
+import os
 
 Postgresql = testing.postgresql.PostgresqlFactory(cache_initialized_db=True)
 # sqlite disables fk constraints by default, this enables them
@@ -18,10 +19,13 @@ def _set_sqlite_pragma(dbapi_connection, connection_record):
 
 @pytest.fixture(scope="function")
 def client():
-    postgresql = Postgresql()
-    app.DB_URI = postgresql.url()
+    if os.environ.get("USE_SQLITE") == "True":
+        app.DB_URI = "sqlite://"
 
-    # app.DB_URI = "sqlite://"
+    else:
+        postgresql = Postgresql()
+        app.DB_URI = postgresql.url()
+
     instance = app.create_app()
     db.create_all(app=instance)
     ctx = instance.app_context()

--- a/app/tests/common.py
+++ b/app/tests/common.py
@@ -4,8 +4,9 @@ import pytest
 from sqlalchemy import event
 from sqlalchemy.engine import Engine
 from sqlite3 import Connection as SQLite3Connection
+import testing.postgresql
 
-
+Postgresql = testing.postgresql.PostgresqlFactory(cache_initialized_db=True)
 # sqlite disables fk constraints by default, this enables them
 @event.listens_for(Engine, "connect")
 def _set_sqlite_pragma(dbapi_connection, connection_record):
@@ -17,7 +18,10 @@ def _set_sqlite_pragma(dbapi_connection, connection_record):
 
 @pytest.fixture(scope="function")
 def client():
-    app.DB_URI = "sqlite://"
+    postgresql = Postgresql()
+    app.DB_URI = postgresql.url()
+
+    # app.DB_URI = "sqlite://"
     instance = app.create_app()
     db.create_all(app=instance)
     ctx = instance.app_context()

--- a/app/tests/factories.py
+++ b/app/tests/factories.py
@@ -47,7 +47,6 @@ class ApplicationFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = Application
         sqlalchemy_session = db.session
 
-    # id = factory.Sequence(lambda n: n)
     name = factory.Sequence(lambda n: f"App {n}")
     application_type = ApplicationType.BUSINESS_APPLICATION
 

--- a/app/tests/factories.py
+++ b/app/tests/factories.py
@@ -47,7 +47,7 @@ class ApplicationFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = Application
         sqlalchemy_session = db.session
 
-    id = factory.Sequence(lambda n: n)
+    # id = factory.Sequence(lambda n: n)
     name = factory.Sequence(lambda n: f"App {n}")
     application_type = ApplicationType.BUSINESS_APPLICATION
 


### PR DESCRIPTION
Moves testing to use Postgres rather than Sqlite in order to make tests more representative of deployed environment

Closes AirWalk-Digital/airview-issues#128